### PR TITLE
remove symlink resolution (os.path.realpath)

### DIFF
--- a/ciopath/gpath_list.py
+++ b/ciopath/gpath_list.py
@@ -171,8 +171,7 @@ class PathList(object):
                 for root, _, files in os.walk(entry.fslash()):
                     for file_name in files:
                         file_path = os.path.join(root, file_name)
-                        resolved_path = os.path.realpath(file_path)
-                        result.append(Path(resolved_path))
+                        result.append(Path(file_path))
 
         self._entries = result
         self._clean = False

--- a/tests/test_gpath.py
+++ b/tests/test_gpath.py
@@ -127,7 +127,9 @@ class MiscPathTest(unittest.TestCase):
 
 class PathExpansionTest(unittest.TestCase):
     def setUp(self):
+
         self.env = {
+            "USERPROFILE": "/users/joebloggs",
             "HOME": "/users/joebloggs",
             "SHOT": "/metropolis/shot01",
             "DEPT": "texturing",

--- a/tests/test_gpath_list.py
+++ b/tests/test_gpath_list.py
@@ -32,6 +32,7 @@ import glob  # isort:skip
 class PathListTest(unittest.TestCase):
     def setUp(self):
         self.env = {
+            "USERPROFILE": "/users/joebloggs",
             "HOME": "/users/joebloggs",
             "SHOT": "/metropolis/shot01",
             "DEPT": "texturing",
@@ -532,11 +533,11 @@ class RemovePatternTest(unittest.TestCase):
 
 class RealFilesTest(unittest.TestCase):
     @patch("os.walk")
-    @patch("os.path.realpath")
+    # @patch("os.path.realpath")
     @patch.object(PathList, "glob")
     @patch.object(Path, "stat")
-    def test_expands_a_folder(self, mock_stat, mock_glob, mock_realpath, mock_walk):
-        mock_realpath.side_effect = lambda x: f"/real{x}"
+    def test_expands_a_folder(self, mock_stat, mock_glob,  mock_walk):
+        # mock_realpath.side_effect = lambda x: f"/real{x}"
         mock_walk.return_value = [
             ("/tmp", ["dir1", "dir2"], ["file1.txt", "file2.txt"]),
             ("/tmp/dir1", [], ["file3.txt", "file4.txt"]),
@@ -548,9 +549,9 @@ class RealFilesTest(unittest.TestCase):
         p.real_files()
         self.assertEqual(len(p), 4)
         self.assertEqual(mock_glob.call_count, 1)
-        self.assertIn("/real/tmp/file1.txt", p)
-        self.assertIn("/real/tmp/dir1/file3.txt", p)
-        self.assertNotIn("/tmp", p)
+        self.assertIn("/tmp/file1.txt", p)
+        self.assertIn("/tmp/dir1/file3.txt", p)
+        # self.assertNotIn("/tmp", p)
 
         # ensure it doesn't add files that are already there
         p.add("/tmp")


### PR DESCRIPTION
## Summary

Could you describe your changes? Please include motivation and context.

Removed the os.path.realpath stuff because : 

1. We want the path in the DCC to be the one that exists on the render node. A resolved link would be wrong.
2. Seems to be buggy when first accessing network, or at least difficult to troubleshoot. 
3. Confusing.

## Issue #13 

## Type of change

- [ ] Non-functional
- [x] Fix
- [ ] Feature
- [ ] Breaking change

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have refactored to remove duplication
- [ ] I have added comments to unidiomatic code (hint: there shouldn't be any)
- [x] I have performed a self-review
- [ ] I have made corresponding changes to the documentation
- [x] I have updated compatibility information in the README
- [x] My changes generate no new warnings
- [ ] I have added tests
- [x] New and existing tests pass locally
- [x] Changes to dependencies have been merged and published

## Screenshots/movies

## Note to reviewers

Please use codes in comments to indicate whether or not action should be taken. For example:
* `[NIT]` Spelling, naming, minor preference, or style issue.
* `[OPT]` Code issue, far from critical. Optional to fix.
* `[REQ]` Requires fixing due to guidelines or critical bugs.

